### PR TITLE
Make tests for both name and cmd to make it more semantically correct on Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,15 @@
 'use strict';
 const psList = require('ps-list');
 
-const fn = (wantedProcessName, process) => {
+const linuxProcessMatchesName = (wantedProcessName, process) => {
+	if (typeof wantedProcessName === 'string') {
+		return process.name === wantedProcessName || process.cmd.split(' ')[0] === wantedProcessName;
+	}
+
+	return process.pid === wantedProcessName;
+};
+
+const nonLinuxProcessMatchesName = (wantedProcessName, process) => {
 	if (typeof wantedProcessName === 'string') {
 		return process.name === wantedProcessName;
 	}
@@ -9,17 +17,19 @@ const fn = (wantedProcessName, process) => {
 	return process.pid === wantedProcessName;
 };
 
+const processMatchesName = process.platform === 'linux' ? linuxProcessMatchesName : nonLinuxProcessMatchesName;
+
 module.exports = async processName => {
 	const processes = await psList();
-	return processes.some(x => fn(processName, x));
+	return processes.some(x => processMatchesName(processName, x));
 };
 
 module.exports.all = async processName => {
 	const processes = await psList();
-	return new Map(processName.map(x => [x, processes.some(y => fn(x, y))]));
+	return new Map(processName.map(x => [x, processes.some(y => processMatchesName(x, y))]));
 };
 
 module.exports.filterExists = async processNames => {
 	const processes = await psList();
-	return processNames.filter(x => processes.some(y => fn(x, y)));
+	return processNames.filter(x => processes.some(y => processMatchesName(x, y)));
 };


### PR DESCRIPTION
Makes test use both cmd and name to check if process matches string `name` in linux as they are easily confused yet can be different.